### PR TITLE
Restructured project settings. Added production settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # node installed modules
 node_modules
+
+# Django development settings
+development_settings.py

--- a/CSRuby/settings/common_settings.py
+++ b/CSRuby/settings/common_settings.py
@@ -19,14 +19,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'jduk5ieuy&-%z1cr@!31c46#0kf^40-&fx3(sud-q#$o#az^ao'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -130,7 +122,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/

--- a/CSRuby/settings/production_settings.py
+++ b/CSRuby/settings/production_settings.py
@@ -1,0 +1,27 @@
+from CSRuby.settings.common_settings import *
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# SET environment variable SECRET_KEY on server
+# SECRET_KEY = os.environ['SECRET_KEY']
+SECRET_KEY = 'jduk5ieuy&-%z1cr@!31c46#0kf^40-&fx3(sud-q#$o#az^ao'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+ALLOWED_HOSTS = ['0.0.0.0', 'localhost']
+
+CSRF_COOKIE_SECURE = True
+
+SESSION_COOKIE_SECURE = True
+
+SECURE_SSL_REDIRECT = True
+
+SECURE_HSTS_SECONDS = 3600
+
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
+SECURE_HSTS_PRELOAD = True
+
+SECURE_REFERRER_POLICY = 'no-referrer'
+
+# TODO:  SET environment variable DJANGO_SETTINGS_MODULE to CSRuby.settings.production_settings on server

--- a/CSRuby/wsgi.py
+++ b/CSRuby/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CSRuby.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CSRuby.settings.development_settings')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CSRuby.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CSRuby.settings.development_settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
# README ⚠
J'ai changer la structure des settings pour faire en sorte de faciliter le job pour le déploiement et de respecter les règles de sécurité de Django (voir https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/ pour plus d'info).

La structure de fichier est la suivante :
```
CSRUby/
| - settings/
    | - common_settings.py
    | - development_settings.py
    | - production_settings.py
```

Quelques informations :
- common_settings.py : contient les settings qui sont commun au dev. et prod.
- development_settings.py : uniquement pour le dev. Il faut le créer car il n'est pas commit ! Contient le ` DEBUG` à **true** et la `SECRET_KEY` en dure
- production_settings.py : uniquement pour la prod. La `SECRET_KEY` est récupéré depuis une variable d'environnement sur le serveur et le `DEBUG` est à **false**